### PR TITLE
Update 0001_initial.py to add ordering meta options to HueySchedule a…

### DIFF
--- a/huey_django_orm/migrations/0001_initial.py
+++ b/huey_django_orm/migrations/0001_initial.py
@@ -30,6 +30,7 @@ class Migration(migrations.Migration):
                 ('timestamp', models.DateTimeField(blank=True, null=True)),
                 ('created', models.DateTimeField(auto_now_add=True, null=True)),
             ],
+            options={'ordering': ('timestamp',)},
         ),
         migrations.CreateModel(
             name='HueyTask',
@@ -40,5 +41,6 @@ class Migration(migrations.Migration):
                 ('priority', models.DecimalField(blank=True, decimal_places=4, max_digits=5, null=True)),
                 ('created', models.DateTimeField(auto_now_add=True, null=True)),
             ],
+            options={'ordering': ('-priority', 'id')},
         ),
     ]


### PR DESCRIPTION
…nd HueyTask models

Adding ordering options to HueySchedule and HueyTask models according to its Meta configuration to prevent Django from showing the following alert upon running "manage.py migrate":
    Your models in app(s): 'huey_django_orm' have changes that are not yet reflected in a migration, and so won't be applied.
    Run 'manage.py makemigrations' to make new migrations, and then re-run 'manage.py migrate' to apply them.